### PR TITLE
Issue #13: findOne should return the instance of the record found or …

### DIFF
--- a/core/DbModel.php
+++ b/core/DbModel.php
@@ -58,6 +58,6 @@ abstract class DbModel extends BaseModel
         }
         $stmt->execute();
         $obj = @$stmt->fetchObject(static::class);
-        return $obj ?: new static();
+        return $obj ?: null;
     }
 }

--- a/models/LoginModel.php
+++ b/models/LoginModel.php
@@ -19,7 +19,6 @@ class LoginModel extends BaseModel
     public function login(): bool
     {
         $user = User::findOne(['email'=>$this->email]);
-        // user should be evaluated at this point, but keeping it for now
         if(!$user) {
             $this->addError('email','User does not exist');
             return false;

--- a/models/User.php
+++ b/models/User.php
@@ -62,7 +62,7 @@ class User extends DbModel
         return ['first_name', 'last_name', 'username', 'email', 'password', 'created_by'];
     }
 
-    public static function findOne(array $where, $tableName = self::TABLE_NAME): User
+    public static function findOne(array $where, $tableName = self::TABLE_NAME): ?User
     {
         return parent::findOne($where, $tableName);
     }


### PR DESCRIPTION
…null.

- Used shorthand version of ternary to return null when object is not found, or when fetchObject fails. (will change on Issue #14)

- User::findOne should also be able to return null.

Resolved #13 