### PR TITLE
#Backend: Add support for new HTTP Methods #32

### DIFF
--- a/core/Request.php
+++ b/core/Request.php
@@ -4,6 +4,10 @@ class Request
 {
     public const GET = 'GET';
     public const POST = 'POST';
+    public const PUT = 'PUT';
+    public const PATCH = 'PATCH';
+    public const DELETE = 'DELETE';
+
     public static function path() {
         $path = $_SERVER['REQUEST_URI'] ?? '/';
         $position = strpos($path, '?');
@@ -26,18 +30,32 @@ class Request
         return self::method() == self::POST;
     }
 
+    public static function isPut(): bool
+    {
+        return self::method() === self::PUT;
+    }
+
+    public static function isPatch(): bool
+    {
+        return self::method() === self::PATCH;
+    }
+
+    public static function isDelete(): bool
+    {
+        return self::method() === self::DELETE;
+    }
+
     /**
-     * @return array - data being submitted
+     * @return array|string - data being submitted
      * You may use $_GET and $_POST directly
      */
-    public static function requestBody(): array
+    public static function requestBody(): array|null
     {
-        if (self::method() == self::GET) {
-            return $_GET;
-        }
-        elseif (self::method() == self::POST) {
-            return $_POST;
-        }
-        return [];
+        return match (self::method()) {
+            self::GET => $_GET ?: null,
+            self::POST => $_POST ?: null,
+            self::PUT, self::PATCH, self::DELETE => json_decode(file_get_contents('php://input'), true),
+            default => null
+        };
     }
 }

--- a/core/Router.php
+++ b/core/Router.php
@@ -18,6 +18,21 @@ class Router
         $this->routes[Request::POST][$path] = $callback; // register the given path as a post request
     }
 
+    public function put($path, $callback): void
+    {
+        $this->routes[Request::PUT][$path] = $callback; // register the given path as a put request
+    }
+
+    public function patch($path, $callback): void
+    {
+        $this->routes[Request::PATCH][$path] = $callback; // register the given path as a patch request
+    }
+
+    public function delete($path, $callback): void
+    {
+        $this->routes[Request::DELETE][$path] = $callback; // register the given path as a delete request
+    }
+
     public function resolve() {
         $path = Request::path();
         $method = Request::method();


### PR DESCRIPTION
- Request
  - Added helper functions for HTTP method validation - isPut() - isPatch() - isDelete()
  - requestBody()
    - Now returns null when the response is empty
    - Match the new methods and return their body as an associative. - For now They will only accept json content.
- Router
  - Added routing functions for the new HTTP methods - put() - patch() - delete()

Resolves #32