### PR TITLE
Issue #69: Implement users level CRUD on API

### DIFF
--- a/controllers/api/APIUserController.php
+++ b/controllers/api/APIUserController.php
@@ -2,7 +2,6 @@
 
 require_once 'core/BaseController.php';
 require_once 'models/User.php';
-require_once 'core/Response.php';
 
 class APIUserController extends BaseController
 {

--- a/controllers/api/APIUserLevelController.php
+++ b/controllers/api/APIUserLevelController.php
@@ -1,26 +1,148 @@
 <?php declare(strict_types=1);
 
 require_once 'core/BaseController.php';
+require_once 'models/UserLevel.php';
 
 class APIUserLevelController extends BaseController
 {
     public function get(): string|array|false
     {
-        return 'get - user_levels';
+        try {
+            if (!Application::$APP->isAuthenticated()) {
+                Response::setStatusCode(401);
+                return Response::json(['message' => 'You are not logged in.']);
+            }
+
+            if (!empty($_GET)) {
+                $userLevel = UserLevel::findOne($_GET);
+                if (is_null($userLevel)) {
+                    Response::setStatusCode(404);
+                    return Response::json(['message' => 'User level not found.']);
+                }
+
+                Response::setStatusCode(200);
+                return Response::json($userLevel);
+            }
+
+            $user_levels = UserLevel::findAll([], []);
+            Response::setStatusCode(200);
+            return Response::json($user_levels);
+        } catch (Exception) {
+            Response::setStatusCode(500);
+            return Response::json(['message' => 'Something went wrong when retrieving user levels.']);
+        }
     }
 
     public function create(): string|array|false
     {
-        return 'create - user_levels';
+        try {
+            if (!Application::$APP->isAuthenticated()) {
+                Response::setStatusCode(401);
+                return Response::json(['message' => 'You are not logged in.']);
+            }
+
+            if (!Application::$APP->getUser()->isAdmin()) {
+                Response::setStatusCode(403);
+                return Response::json(['message' => 'You are not allowed to create user levels.']);
+            }
+
+            $user_level = new UserLevel();
+            $user_level->loadData(Request::requestBody());
+
+            $user_level_id = $user_level->save();
+            if (!$user_level_id) {
+                Response::setStatusCode(500);
+                return Response::json(['message' => 'Something went wrong when creating user level.']);
+            }
+
+            $user_level->user_level_id = (int)$user_level_id;
+            Response::setStatusCode(201);
+            return Response::json($user_level);
+        } catch (Exception) {
+            Response::setStatusCode(500);
+            return Response::json(['message' => 'Something went wrong when creating user level.']);
+        }
     }
 
     public function update(): string|array|false
     {
-        return 'update - user_levels';
+        try {
+            if (!Application::$APP->isAuthenticated()) {
+                Response::setStatusCode(401);
+                return Response::json(['message' => 'You are not logged in.']);
+            }
+
+            $request_user_level_id = (int)$_REQUEST['user_level_id'] ?? null;
+
+            if (is_null($request_user_level_id)) {
+                Response::setStatusCode(400);
+                return Response::json(['message' => 'Failed to edit user level.', 'errors' => ['user_level_id' => 'User level ID must be specified in the query parameters.']]);
+            }
+
+            if (!Application::$APP->getUser()->isAdmin()) {
+                Response::setStatusCode(403);
+                return Response::json(['message' => 'You are not allowed to edit user levels.']);
+            }
+
+            if (is_null(UserLevel::findOne(['user_level_id' => $request_user_level_id]))) {
+                Response::setStatusCode(404);
+                return Response::json(['message' => 'User level with user_level_id ' . $request_user_level_id . ' not found.']);
+            }
+
+            $user = new UserLevel();
+            $user->loadData(Request::requestBody());
+            $user->user_level_id = $request_user_level_id;
+
+            if (!$user->update()) {
+                Response::setStatusCode(500);
+                return Response::json(['message' => 'Something went wrong when editing user level.']);
+            }
+
+            Response::setStatusCode(200);
+            return Response::json($user);
+        } catch (Exception) {
+            Response::setStatusCode(500);
+            return Response::json(['message' => 'Something went wrong when editing user level.']);
+        }
     }
 
     public function delete(): string|array|false
     {
-        return 'delete - user_levels';
+        try {
+            if (!Application::$APP->isAuthenticated()) {
+                Response::setStatusCode(401);
+                return Response::json(['message' => 'You are not logged in.']);
+            }
+
+            $request_user_level_id = $_REQUEST['user_level_id'] ?? null;
+
+            if (is_null($request_user_level_id)) {
+                Response::setStatusCode(400);
+                return Response::json(['message' => 'Failed to delete user level.', 'errors' => ['user_level_id' => 'User level ID must be specified in the query parameters.']]);
+            }
+
+            if (!Application::$APP->getUser()->isAdmin()) {
+                Response::setStatusCode(403);
+                return Response::json(['message' => 'You are not allowed to delete user levels.']);
+            }
+
+            $user = UserLevel::findOne(['user_level_id' => $request_user_level_id]);
+
+            if (is_null($user)) {
+                Response::setStatusCode(404);
+                return Response::json(['message' => 'User level with user_level_id ' . $request_user_level_id . ' not found.']);
+            }
+
+            if ($user->delete()) {
+                Response::setStatusCode(200);
+                return Response::json(['message' => 'User level deleted successfully !']);
+            } else {
+                Response::setStatusCode(500);
+                return Response::json(['message' => 'Failed to delete user level.']);
+            }
+        } catch (Exception) {
+            Response::setStatusCode(500);
+            return Response::json(['message' => 'Something went wrong when deleting user level.']);
+        }
     }
 }

--- a/models/User.php
+++ b/models/User.php
@@ -13,7 +13,7 @@ class User extends DbModel
     public string $created_by;
     public int $user_level_id;
     public string $created_at;
-    public string|null $birthday;
+    public string|null $birthday = null;
 
     // Important: To skip mapping columns from findOne and findAll methods, mark the properties as private
     private int|null $questions_submitted;

--- a/models/UserLevel.php
+++ b/models/UserLevel.php
@@ -6,7 +6,7 @@ class UserLevel extends DbModel
 {
     public int $user_level_id;
     public string $name;
-    public string $description;
+    public string|null $description = null;
 
     private const TABLE_NAME = 'user_levels';
 
@@ -44,7 +44,7 @@ class UserLevel extends DbModel
         return ['name', 'description'];
     }
 
-    public static function findOne(array $where, $tableName = self::TABLE_NAME): ?User
+    public static function findOne(array $where, $tableName = self::TABLE_NAME): ?UserLevel
     {
         return parent::findOne($where, $tableName);
     }


### PR DESCRIPTION
- We will set optional (nullable fields) to {type}|null in their model classes, otherwise write operations won't work if we don't include them in the request body.
- Slightly optimized imports in APIUserController.php