### PR TITLE
Issue #73: Implement questions CRUD on API and Front

### DIFF
--- a/controllers/QuestionController.php
+++ b/controllers/QuestionController.php
@@ -3,19 +3,29 @@ require_once 'core/BaseController.php';
 
 class QuestionController extends BaseController {
 
-        public function list(): string|array|false
-        {
-            return Application::$APP->getRouter()->renderView('init', ['endpoint' => 'questions']);
-        }
+    public function list(): string|array|false
+    {
+        return Application::$APP->getRouter()->renderView('init', ['endpoint' => 'questions']);
+    }
 
-        public function categories(): string|array|false
-        {
-            return Application::$APP->getRouter()->renderView('init', ['endpoint' =>'question_categories']);
-        }
+    public function create(): string|array|false
+    {
+        return Application::$APP->getRouter()->renderView('init', ['endpoint' => '/user_levels/create']);
+    }
 
-        public function levels(): string|array|false
-        {
-            return Application::$APP->getRouter()->renderView('init', ['endpoint' =>'question_levels']);
-        }
+    public function edit(): string|array|false
+    {
+        return Application::$APP->getRouter()->renderView('init', ['endpoint' => '/user_levels/edit']);
+    }
 
+    // TODO: Eventually, move these in separate controllers when you implement their APIs to keep things clean
+    public function categories(): string|array|false
+    {
+        return Application::$APP->getRouter()->renderView('init', ['endpoint' => 'question_categories']);
+    }
+
+    public function levels(): string|array|false
+    {
+        return Application::$APP->getRouter()->renderView('init', ['endpoint' => 'question_levels']);
+    }
 }

--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -4,11 +4,6 @@ require_once 'core/BaseController.php';
 
 class UserController extends BaseController
 {
-    public function edit(): string|array|false
-    {
-        return Application::$APP->getRouter()->renderView('init', ['endpoint' => '/users/edit']);
-    }
-
     public function list(): string|array|false
     {
         return Application::$APP->getRouter()->renderView('init', ['endpoint' => '/users']);
@@ -17,5 +12,10 @@ class UserController extends BaseController
     public function create(): string|array|false
     {
         return Application::$APP->getRouter()->renderView('init', ['endpoint' => '/users/create']);
+    }
+
+    public function edit(): string|array|false
+    {
+        return Application::$APP->getRouter()->renderView('init', ['endpoint' => '/users/edit']);
     }
 }

--- a/controllers/UserLevelController.php
+++ b/controllers/UserLevelController.php
@@ -4,11 +4,6 @@ require_once 'core/BaseController.php';
 
 class UserLevelController extends BaseController
 {
-    public function edit(): string|array|false
-    {
-        return Application::$APP->getRouter()->renderView('init', ['endpoint' => '/user_levels/edit']);
-    }
-
     public function list(): string|array|false
     {
         return Application::$APP->getRouter()->renderView('init', ['endpoint' => '/user_levels']);
@@ -17,5 +12,10 @@ class UserLevelController extends BaseController
     public function create(): string|array|false
     {
         return Application::$APP->getRouter()->renderView('init', ['endpoint' => '/user_levels/create']);
+    }
+
+    public function edit(): string|array|false
+    {
+        return Application::$APP->getRouter()->renderView('init', ['endpoint' => '/user_levels/edit']);
     }
 }

--- a/controllers/api/APIQuestionController.php
+++ b/controllers/api/APIQuestionController.php
@@ -1,0 +1,148 @@
+<?php
+
+require_once 'models/Question.php';
+
+class APIQuestionController extends BaseController
+{
+    public function get(): string|array|false
+    {
+        try {
+            if (!Application::$APP->isAuthenticated()) {
+                Response::setStatusCode(401);
+                return Response::json(['message' => 'You are not logged in.']);
+            }
+
+            if (!empty($_GET)) {
+                $question = Question::findOne($_GET);
+                if (is_null($question)) {
+                    Response::setStatusCode(404);
+                    return Response::json(['message' => 'Question not found.']);
+                }
+
+                Response::setStatusCode(200);
+                return Response::json($question);
+            }
+
+            $questions = Question::findAll([], []);
+            Response::setStatusCode(200);
+            return Response::json($questions);
+        } catch (Exception) {
+            Response::setStatusCode(500);
+            return Response::json(['message' => 'Something went wrong when retrieving questions.']);
+        }
+    }
+
+    public function create(): string|array|false
+    {
+        try {
+            if (!Application::$APP->isAuthenticated()) {
+                Response::setStatusCode(401);
+                return Response::json(['message' => 'You are not logged in.']);
+            }
+
+            if (!Application::$APP->getUser()->isAdmin() && !Application::$APP->getUser()->isTeacher()) {
+                Response::setStatusCode(403);
+                return Response::json(['message' => 'You are not allowed to create questions.']);
+            }
+
+            $question = new Question();
+            $question->loadData(Request::requestBody());
+
+            $question_id = $question->save();
+            if (!$question_id) {
+                Response::setStatusCode(500);
+                return Response::json(['message' => 'Something went wrong when creating question.']);
+            }
+
+            $question->question_id = (int)$question_id;
+            Response::setStatusCode(201);
+            return Response::json($question);
+        } catch (Exception $e) {
+            return Response::json(['message' => $e->getMessage()]);
+            Response::setStatusCode(500);
+            return Response::json(['message' => 'Something went wrong when creating question.']);
+        }
+    }
+
+    public function update(): string|array|false
+    {
+        try {
+            if (!Application::$APP->isAuthenticated()) {
+                Response::setStatusCode(401);
+                return Response::json(['message' => 'You are not logged in.']);
+            }
+
+            $request_question_id = (int)$_REQUEST['question_id'] ?? null;
+
+            if (is_null($request_question_id)) {
+                Response::setStatusCode(400);
+                return Response::json(['message' => 'Failed to edit question.', 'errors' => ['question_id' => 'Question ID must be specified in the query parameters.']]);
+            }
+
+            if (!Application::$APP->getUser()->isAdmin() && !Application::$APP->getUser()->isTeacher()) {
+                Response::setStatusCode(403);
+                return Response::json(['message' => 'You are not allowed to edit questions.']);
+            }
+
+            if (is_null(Question::findOne(['question_id' => $request_question_id]))) {
+                Response::setStatusCode(404);
+                return Response::json(['message' => 'Question with question_id ' . $request_question_id . ' not found.']);
+            }
+
+            $user = new Question();
+            $user->loadData(Request::requestBody());
+            $user->question_id = $request_question_id;
+
+            if (!$user->update()) {
+                Response::setStatusCode(500);
+                return Response::json(['message' => 'Something went wrong when editing question.']);
+            }
+
+            Response::setStatusCode(200);
+            return Response::json($user);
+        } catch (Exception) {
+            Response::setStatusCode(500);
+            return Response::json(['message' => 'Something went wrong when editing question.']);
+        }
+    }
+
+    public function delete(): string|array|false
+    {
+        try {
+            if (!Application::$APP->isAuthenticated()) {
+                Response::setStatusCode(401);
+                return Response::json(['message' => 'You are not logged in.']);
+            }
+
+            $request_question_id = $_REQUEST['question_id'] ?? null;
+
+            if (is_null($request_question_id)) {
+                Response::setStatusCode(400);
+                return Response::json(['message' => 'Failed to delete question.', 'errors' => ['question_id' => 'Question ID must be specified in the query parameters.']]);
+            }
+
+            if (!Application::$APP->getUser()->isAdmin() && !Application::$APP->getUser()->isTeacher()) {
+                Response::setStatusCode(403);
+                return Response::json(['message' => 'You are not allowed to delete questions.']);
+            }
+
+            $user = Question::findOne(['question_id' => $request_question_id]);
+
+            if (is_null($user)) {
+                Response::setStatusCode(404);
+                return Response::json(['message' => 'Question with question_id ' . $request_question_id . ' not found.']);
+            }
+
+            if ($user->delete()) {
+                Response::setStatusCode(200);
+                return Response::json(['message' => 'Question deleted successfully !']);
+            } else {
+                Response::setStatusCode(500);
+                return Response::json(['message' => 'Failed to delete question.']);
+            }
+        } catch (Exception) {
+            Response::setStatusCode(500);
+            return Response::json(['message' => 'Something went wrong when deleting question.']);
+        }
+    }
+}

--- a/core/api_routes.php
+++ b/core/api_routes.php
@@ -2,6 +2,7 @@
 
 require_once 'controllers/api/APIUserController.php';
 require_once 'controllers/api/APIUserLevelController.php';
+require_once 'controllers/api/APIQuestionController.php';
 
 // users
 $app->getRouter()->get('/api/users', [APIUserController::class, 'get']);
@@ -14,3 +15,9 @@ $app->getRouter()->get('/api/user_levels', [APIUserLevelController::class, 'get'
 $app->getRouter()->post('/api/user_levels/create', [APIUserLevelController::class, 'create']);
 $app->getRouter()->put('/api/user_levels/update', [APIUserLevelController::class, 'update']);
 $app->getRouter()->delete('/api/user_levels/delete', [APIUserLevelController::class, 'delete']);
+
+// questions
+$app->getRouter()->get('/api/questions', [APIQuestionController::class, 'get']);
+$app->getRouter()->post('/api/questions/create', [APIQuestionController::class, 'create']);
+$app->getRouter()->put('/api/questions/update', [APIQuestionController::class, 'update']);
+$app->getRouter()->delete('/api/questions/delete', [APIQuestionController::class, 'delete']);

--- a/core/dev_db.sql
+++ b/core/dev_db.sql
@@ -998,13 +998,22 @@ CREATE TABLE IF NOT EXISTS `favourite_questions`
 )
     );
 
-INSERT IGNORE INTO `user_levels` (`user_level_id`, `name`)
+INSERT
+IGNORE INTO `user_levels` (`user_level_id`, `name`)
 VALUES (1, 'Admin'),
        (2, 'Teacher'),
        (3, 'Student');
 
-INSERT IGNORE INTO `users` (`user_id`, `first_name`, `last_name`, `username`, `password`, `email`, `user_level_id`, `created_by`)
+INSERT
+IGNORE INTO `users` (`user_id`, `first_name`, `last_name`, `username`, `password`, `email`, `user_level_id`, `created_by`)
 VALUES (1, 'Detjon', 'Mataj', 'admin1', '{{admin_password}}', 'admin1@cpp.edu', 3, 'admin1');
 
-INSERT IGNORE INTO `users` (`user_id`, `first_name`, `last_name`, `username`, `password`, `email`, `user_level_id`, `created_by`)
+INSERT
+IGNORE INTO `users` (`user_id`, `first_name`, `last_name`, `username`, `password`, `email`, `user_level_id`, `created_by`)
 VALUES (2, 'Drin', 'Karkini', 'admin2', '{{admin_password}}', 'admin2@cpp.edu', 3, 'admin2');
+
+INSERT
+IGNORE INTO `question_levels`
+VALUES (1, 'Easy'),
+       (2, 'Medium'),
+       (3, 'Hard');

--- a/core/front_routes.php
+++ b/core/front_routes.php
@@ -23,17 +23,23 @@ $app->getRouter()->get('/register', [AuthController::class, 'register']);
 $app->getRouter()->post('/register', [AuthController::class, 'register']);
 $app->getRouter()->get('/logout', [AuthController::class, 'logout']);
 
-// questions
-$app->getRouter()->get('/questions', [QuestionController::class, 'list']);
-$app->getRouter()->get('/question_categories', [QuestionController::class, 'categories']);
-$app->getRouter()->get('/question_levels', [QuestionController::class, 'levels']);
-
 // users
-$app->getRouter()->get('/users/edit', [UserController::class, 'edit']);
 $app->getRouter()->get('/users', [UserController::class, 'list']);
 $app->getRouter()->get('/users/create', [UserController::class, 'create']);
+$app->getRouter()->get('/users/edit', [UserController::class, 'edit']);
 
 // user_levels
-$app->getRouter()->get('/user_levels/edit', [UserLevelController::class, 'edit']);
 $app->getRouter()->get('/user_levels', [UserLevelController::class, 'list']);
 $app->getRouter()->get('/user_levels/create', [UserLevelController::class, 'create']);
+$app->getRouter()->get('/user_levels/edit', [UserLevelController::class, 'edit']);
+
+// questions
+$app->getRouter()->get('/questions', [QuestionController::class, 'list']);
+$app->getRouter()->get('/questions/create', [QuestionController::class, 'create']);
+$app->getRouter()->get('/questions/edit', [QuestionController::class, 'edit']);
+
+// question categories
+$app->getRouter()->get('/question_categories', [QuestionController::class, 'categories']);
+
+// question levels
+$app->getRouter()->get('/question_levels', [QuestionController::class, 'levels']);

--- a/models/Question.php
+++ b/models/Question.php
@@ -1,0 +1,71 @@
+<?php
+
+require_once 'core/DbModel.php';
+
+class Question extends DbModel
+{
+    public int $question_id;
+    public string $title;
+    public string $description;
+    public string $hint = '';
+    public int $user_id;
+    public string $created_at;
+    public int $question_level_id;
+
+    private ?int $volume_id;
+    private ?int $question_category_id;
+
+    private const TABLE_NAME = 'questions';
+
+    public function rules(): array
+    {
+        return [
+            'title' => [self::RULE_REQUIRED],
+            'user_id' => [self::RULE_REQUIRED],
+            'question_level_id' => [self::RULE_REQUIRED],
+        ];
+    }
+
+    /**
+     * @return string[]
+     * keys should correspond to the attributes and values will be displayed in the HTML document
+     */
+    public function labels(): array
+    {
+        return [
+            'title' => 'Title',
+            'user_id' => 'Created by',
+            'question_level_id' => 'Difficulty',
+        ];
+    }
+
+    public function tableName(): string
+    {
+        return self::TABLE_NAME;
+    }
+
+    /**
+     * @return string[]
+     * return all the DB properties of this class
+     * you may create other properties not part of the DB model
+     */
+    public function attributes(): array
+    {
+        return ['title', 'description', 'hint', 'user_id', 'question_level_id'];
+    }
+
+    public static function findOne(array $where, string $tableName = self::TABLE_NAME): ?Question
+    {
+        return parent::findOne($where, $tableName);
+    }
+
+    public static function findAll(array $where, array $extraClauses, string $tableName = self::TABLE_NAME): ?array
+    {
+        return parent::findAll($where, $extraClauses, $tableName);
+    }
+
+    public function primaryKey(): string
+    {
+        return 'question_id';
+    }
+}

--- a/models/User.php
+++ b/models/User.php
@@ -13,12 +13,13 @@ class User extends DbModel
     public string $created_by;
     public int $user_level_id;
     public string $created_at;
-    public string|null $birthday = null;
+    public ?string $birthday = null;
 
     // Important: To skip mapping columns from findOne and findAll methods, mark the properties as private
-    private int|null $questions_submitted;
-    private int|null $questions_solved;
-    private int|null $questions_rejected;
+    // For columns that are skipped from mapping a default value is not required, but we have to specify the type as ?{data_type}
+    private ?int $questions_submitted;
+    private ?int $questions_solved;
+    private ?int $questions_rejected;
 
     private const TABLE_NAME = 'users';
 
@@ -119,5 +120,10 @@ class User extends DbModel
     public function isAdmin(): bool
     {
         return $this->user_level_id === 1;
+    }
+
+    public function isTeacher(): bool
+    {
+        return $this->user_level_id === 2;
     }
 }


### PR DESCRIPTION
- We have to set default values for all optional properties (not just nullable fields) otherwise the API won't work as intended like with hint in Question.php
- For columns that are skipped from mapping a default value is not required, but we have to specify the type as ?{data_type}
- Add Question CRUD routes for front and API
- Add Question model
- Add API Question Controller
- Modify Front Question Controller
- Bootstrap question_levels in dev_db.sql
- Add an isTeacher() method in User.php

Resolves #73 